### PR TITLE
golang version bump, test fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.19
+          go-version: ^1.22
         id: go
 
       - name: Check out code into the Go module directory
@@ -27,7 +27,7 @@ jobs:
           go install go.uber.org/mock/mockgen@latest
           go get github.com/hashicorp/go-tfe
           mkdir -p mock-go-tfe
-          mockgen github.com/hashicorp/go-tfe Workspaces,Runs,Variables,StateVersions > mock-go-tfe/mocks.go
+          mockgen -package mock_go_tfe github.com/hashicorp/go-tfe Workspaces,Runs,Variables,StateVersions > mock-go-tfe/mocks.go
           go get -v ./...
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 --output cc-test-reporter
           chmod +x cc-test-reporter

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 
 makemocks:
 	mkdir -p mock-go-tfe
-	mockgen github.com/hashicorp/go-tfe Workspaces,Runs,Variables,StateVersions > mock-go-tfe/mocks.go
+	mockgen -package=mock_go_tfe github.com/hashicorp/go-tfe Workspaces,Runs,Variables,StateVersions > mock-go-tfe/mocks.go
 
 test: makemocks
 	#golangci-lint run


### PR DESCRIPTION
- bump to go 1.22
- tell mockgen to use the same package name that it used to